### PR TITLE
feat: Task 3 & 4 - 前端完善和Docker部署

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,53 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.pyo
+*.pyd
+.Python
+
+# Virtual environments
+.venv/
+venv/
+env/
+ENV/
+
+# Testing & coverage
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+*.egg-info/
+
+# SQLite databases (use Docker volume instead)
+*.db
+*.db-journal
+*.sqlite
+*.sqlite3
+
+# Environment / secrets
+.env
+.env.*
+!.env.example
+
+# IDE / OS
+.DS_Store
+Thumbs.db
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Git
+.git/
+.gitignore
+
+# Docs
+*.md
+DESIGN.md
+LICENSE
+
+# Docker files themselves (already in build context root)
+Dockerfile*
+docker-compose*.yml
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,55 @@
+# ─── Build stage ──────────────────────────────────────────────────────────────
+# Compile dependencies in a separate layer so the final image stays slim.
+FROM python:3.11-slim AS builder
+
+WORKDIR /build
+
+# Install build tools needed for some Python packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy only requirements first (better layer caching)
+COPY requirements.txt .
+
+# Install into a local directory so we can copy it cleanly
+RUN pip install --upgrade pip \
+    && pip install --prefix=/install --no-cache-dir -r requirements.txt
+
+
+# ─── Runtime stage ────────────────────────────────────────────────────────────
+FROM python:3.11-slim AS runtime
+
+# Non-root user for security
+RUN groupadd --gid 1001 appgroup \
+    && useradd --uid 1001 --gid appgroup --no-create-home appuser
+
+WORKDIR /app
+
+# Copy installed packages from builder
+COPY --from=builder /install /usr/local
+
+# Copy application source
+COPY --chown=appuser:appgroup app/       ./app/
+COPY --chown=appuser:appgroup templates/ ./templates/
+COPY --chown=appuser:appgroup static/    ./static/
+
+# Ensure data directory for SQLite is writable
+RUN mkdir -p /data && chown appuser:appgroup /data
+
+USER appuser
+
+# Environment defaults (can be overridden via docker-compose or -e flags)
+ENV DATABASE_URL="sqlite+aiosqlite:////data/shorturl.db" \
+    REDIS_URL="redis://redis:6379/0" \
+    BASE_URL="http://localhost:8000" \
+    DEFAULT_EXPIRE_DAYS=30 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/').read()" || exit 1
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,249 @@
+# 🔗 ShortURL Service
+
+A lightweight, production-ready URL shortening service built with **FastAPI**, **SQLite**, and **Redis**.
+
+[![FastAPI](https://img.shields.io/badge/FastAPI-0.115-009688?logo=fastapi)](https://fastapi.tiangolo.com)
+[![Python](https://img.shields.io/badge/Python-3.11-3776AB?logo=python)](https://python.org)
+[![Redis](https://img.shields.io/badge/Redis-7-DC382D?logo=redis)](https://redis.io)
+[![Docker](https://img.shields.io/badge/Docker-Compose-2496ED?logo=docker)](https://docs.docker.com/compose/)
+
+---
+
+## ✨ Features
+
+- **Create short links** with configurable expiry (7 / 30 / 90 days)
+- **QR Code** generation for every short link
+- **Visit statistics** — track access count and last-visited time
+- **Redis caching** for near-zero-latency redirects
+- **Startup cleanup** — expired records are pruned automatically on boot
+- **Responsive UI** — works great on mobile and desktop
+- **Docker-ready** — one command to run everything
+
+---
+
+## 🚀 Quick Start (Docker)
+
+```bash
+# 1. Clone the repository
+git clone https://github.com/Richardpangster/shorturl-service.git
+cd shorturl-service
+
+# 2. Start all services
+docker-compose up -d
+
+# 3. Open in browser
+open http://localhost:8000
+```
+
+> The first build downloads dependencies and may take ~60 seconds.  
+> Subsequent starts are instant.
+
+### Stop & clean up
+
+```bash
+docker-compose down          # stop containers, keep data
+docker-compose down -v       # stop containers and delete volume
+```
+
+---
+
+## 🛠 Local Development
+
+### Prerequisites
+
+- Python 3.11+
+- Redis (optional — the app starts without it and falls back gracefully)
+
+### Setup
+
+```bash
+# Create and activate virtual environment
+python -m venv .venv
+source .venv/bin/activate   # Windows: .venv\Scripts\activate
+
+# Install dependencies
+pip install -r requirements.txt
+
+# (Optional) copy and edit environment variables
+cp .env.example .env
+
+# Run the dev server
+uvicorn app.main:app --reload
+```
+
+Open <http://localhost:8000> in your browser.
+
+### Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `DATABASE_URL` | `sqlite+aiosqlite:///./shorturl.db` | Async SQLAlchemy DB URL |
+| `REDIS_URL` | `redis://localhost:6379/0` | Redis connection string |
+| `BASE_URL` | `http://localhost:8000` | Public base URL used in short links |
+| `DEFAULT_EXPIRE_DAYS` | `30` | Default link expiry in days |
+| `SHORT_CODE_LENGTH` | `6` | Length of generated short codes |
+
+### Run Tests
+
+```bash
+pytest -v
+```
+
+---
+
+## 📡 API Reference
+
+### POST `/api/shorten` — Create a short URL
+
+**Request body**
+
+```json
+{
+  "url": "https://example.com/very/long/path?with=query",
+  "expire_days": 30
+}
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `url` | string (URL) | ✅ | The original long URL |
+| `expire_days` | integer | ❌ | Days until expiry (default: 30) |
+
+**Response `201 Created`**
+
+```json
+{
+  "short_code": "aB3xY9",
+  "short_url": "http://localhost:8000/aB3xY9",
+  "original_url": "https://example.com/very/long/path?with=query",
+  "expires_at": "2025-04-01T12:00:00+00:00"
+}
+```
+
+---
+
+### GET `/{short_code}` — Redirect to original URL
+
+Redirects with **302 Found** to the original URL.  
+Returns **404** if the code doesn't exist or has expired.
+
+---
+
+### GET `/api/stats/{short_code}` — Get visit statistics
+
+**Response `200 OK`**
+
+```json
+{
+  "short_code": "aB3xY9",
+  "original_url": "https://example.com/very/long/path?with=query",
+  "created_at": "2025-03-01T12:00:00+00:00",
+  "expires_at": "2025-04-01T12:00:00+00:00",
+  "visit_count": 42,
+  "last_visited_at": "2025-03-15T08:30:00+00:00"
+}
+```
+
+Returns **404** if the short code doesn't exist or has expired.
+
+---
+
+## 🐳 Docker Details
+
+### Architecture
+
+```
+┌─────────────────────────────────────────────┐
+│                docker-compose               │
+│                                             │
+│  ┌──────────────────┐  ┌─────────────────┐  │
+│  │  web (FastAPI)   │  │  redis:7-alpine │  │
+│  │  port 8000       │──│  port 6379      │  │
+│  │  SQLite → /data  │  │  (cache only)   │  │
+│  └──────────────────┘  └─────────────────┘  │
+│              │                               │
+│  volume: shorturl_data (SQLite DB)           │
+└─────────────────────────────────────────────┘
+```
+
+### Image size
+
+The multi-stage `Dockerfile` keeps the runtime image small:
+- **Builder stage**: compiles Python wheels
+- **Runtime stage**: `python:3.11-slim` + app code only (~150 MB)
+
+### Custom base URL
+
+When deploying behind a reverse proxy, set `BASE_URL`:
+
+```bash
+BASE_URL=https://short.example.com docker-compose up -d
+```
+
+Or add it to a `.env` file:
+
+```dotenv
+BASE_URL=https://short.example.com
+```
+
+---
+
+## 🗂 Project Structure
+
+```
+shorturl-service/
+├── app/
+│   ├── main.py          # FastAPI app, lifespan, startup cleanup
+│   ├── config.py        # Pydantic settings
+│   ├── database.py      # Async SQLAlchemy engine & session
+│   ├── models.py        # URL ORM model
+│   ├── services.py      # Business logic (create, resolve, stats, cleanup)
+│   ├── cache.py         # Redis helpers
+│   └── routers/
+│       ├── api.py       # POST /api/shorten, GET /api/stats/{code}
+│       ├── pages.py     # GET / (Jinja2 frontend)
+│       └── redirect.py  # GET /{short_code}
+├── templates/
+│   └── index.html       # Frontend (HTML/CSS/JS + QRCode.js)
+├── static/
+│   └── style.css        # Responsive stylesheet
+├── tests/
+│   ├── conftest.py
+│   └── test_api.py
+├── Dockerfile           # Multi-stage build
+├── docker-compose.yml   # FastAPI + Redis services
+├── .dockerignore
+├── requirements.txt
+└── README.md
+```
+
+---
+
+## 🔧 Maintenance
+
+### Manual cleanup of expired links
+
+Expired URLs are automatically cleaned up when the service starts. To trigger cleanup manually:
+
+```bash
+# Inside the running container
+docker-compose exec web python -c "
+import asyncio
+from app.database import AsyncSessionLocal
+from app.services import cleanup_expired_urls
+
+async def main():
+    async with AsyncSessionLocal() as db:
+        n = await cleanup_expired_urls(db)
+        await db.commit()
+        print(f'Deleted {n} expired record(s)')
+
+asyncio.run(main())
+"
+```
+
+---
+
+## 📝 License
+
+[MIT](LICENSE)

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,6 @@
 """FastAPI application entry point for ShortURL Service."""
 
+import logging
 from contextlib import asynccontextmanager
 from typing import AsyncIterator
 
@@ -7,16 +8,40 @@ from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 
 from app.cache import close_redis
-from app.database import init_db
+from app.database import AsyncSessionLocal, init_db
 from app.routers import api, pages, redirect
+from app.services import cleanup_expired_urls
+
+logger = logging.getLogger(__name__)
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
-    """Manage application startup and shutdown lifecycle."""
+    """Manage application startup and shutdown lifecycle.
+
+    On startup:
+        - Initialises database tables.
+        - Cleans up any expired short URL records.
+
+    On shutdown:
+        - Closes Redis connection pool.
+    """
     # Startup
     await init_db()
+
+    # Clean up expired records on boot
+    async with AsyncSessionLocal() as session:
+        try:
+            count = await cleanup_expired_urls(session)
+            await session.commit()
+            if count:
+                logger.info("Startup cleanup removed %d expired URL(s).", count)
+        except Exception as exc:  # pragma: no cover
+            logger.warning("Startup cleanup failed: %s", exc)
+            await session.rollback()
+
     yield
+
     # Shutdown
     await close_redis()
 

--- a/app/routers/pages.py
+++ b/app/routers/pages.py
@@ -1,66 +1,21 @@
-"""Pages router: GET / → serves the frontend HTML page."""
+"""Pages router: GET / → serves the frontend HTML page via Jinja2 template."""
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
 
 router = APIRouter(tags=["pages"])
+templates = Jinja2Templates(directory="templates")
 
 
 @router.get("/", response_class=HTMLResponse, include_in_schema=False)
-async def index() -> HTMLResponse:
-    """Serve the simple URL shortener frontend page."""
-    html = """<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>ShortURL Service</title>
-  <link rel="stylesheet" href="/static/style.css" />
-</head>
-<body>
-  <div class="container">
-    <h1>🔗 ShortURL Service</h1>
-    <form id="shorten-form">
-      <input type="url" id="url-input" placeholder="Paste your long URL here…" required />
-      <button type="submit">Shorten</button>
-    </form>
-    <div id="result" class="hidden">
-      <p>Your short URL:</p>
-      <a id="short-link" href="#" target="_blank"></a>
-    </div>
-    <div id="error" class="hidden error"></div>
-  </div>
-  <script>
-    document.getElementById('shorten-form').addEventListener('submit', async (e) => {
-      e.preventDefault();
-      const url = document.getElementById('url-input').value;
-      const resultEl = document.getElementById('result');
-      const errorEl = document.getElementById('error');
-      const linkEl = document.getElementById('short-link');
-      resultEl.classList.add('hidden');
-      errorEl.classList.add('hidden');
-      try {
-        const res = await fetch('/api/shorten', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ url }),
-        });
-        if (!res.ok) {
-          const data = await res.json();
-          errorEl.textContent = data.detail || 'An error occurred.';
-          errorEl.classList.remove('hidden');
-          return;
-        }
-        const data = await res.json();
-        linkEl.href = data.short_url;
-        linkEl.textContent = data.short_url;
-        resultEl.classList.remove('hidden');
-      } catch (err) {
-        errorEl.textContent = 'Network error.';
-        errorEl.classList.remove('hidden');
-      }
-    });
-  </script>
-</body>
-</html>"""
-    return HTMLResponse(content=html)
+async def index(request: Request) -> HTMLResponse:
+    """Serve the URL shortener frontend page using Jinja2 template.
+
+    Args:
+        request: The incoming FastAPI request (required by Jinja2Templates).
+
+    Returns:
+        An HTML response rendered from ``templates/index.html``.
+    """
+    return templates.TemplateResponse(request, "index.html")

--- a/app/services.py
+++ b/app/services.py
@@ -1,15 +1,18 @@
 """Business logic layer for ShortURL Service.
 
 Handles short code generation, URL creation, redirect resolution,
-statistics retrieval, and expiry enforcement.
+statistics retrieval, expiry enforcement, and cleanup utilities.
 """
 
+import logging
 import secrets
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
-from sqlalchemy import select, update
+from sqlalchemy import delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
 
 from app.cache import cache_delete, cache_get, cache_set
 from app.config import settings
@@ -205,3 +208,25 @@ async def delete_short_url(db: AsyncSession, short_code: str) -> bool:
     await db.delete(url_record)
     await cache_delete(short_code)
     return True
+
+
+async def cleanup_expired_urls(db: AsyncSession) -> int:
+    """Delete all expired short URL records from the database.
+
+    This should be called on startup or as a periodic maintenance task.
+    Expired records are those where ``expires_at`` is in the past.
+
+    Args:
+        db: Async SQLAlchemy session.
+
+    Returns:
+        The number of records deleted.
+    """
+    now = _utcnow()
+    result = await db.execute(
+        delete(URL).where(URL.expires_at < now)
+    )
+    deleted_count: int = result.rowcount  # type: ignore[assignment]
+    if deleted_count:
+        logger.info("Cleaned up %d expired URL record(s).", deleted_count)
+    return deleted_count

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+services:
+  # ─── FastAPI Application ────────────────────────────────────────────────────
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: shorturl_web
+    restart: unless-stopped
+    ports:
+      - "8000:8000"
+    environment:
+      DATABASE_URL: "sqlite+aiosqlite:////data/shorturl.db"
+      REDIS_URL: "redis://redis:6379/0"
+      BASE_URL: "${BASE_URL:-http://localhost:8000}"
+      DEFAULT_EXPIRE_DAYS: "${DEFAULT_EXPIRE_DAYS:-30}"
+    volumes:
+      # Persist SQLite database outside the container
+      - shorturl_data:/data
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c",
+             "import urllib.request; urllib.request.urlopen('http://localhost:8000/').read()"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
+
+  # ─── Redis Cache ────────────────────────────────────────────────────────────
+  redis:
+    image: redis:7-alpine
+    container_name: shorturl_redis
+    restart: unless-stopped
+    command: ["redis-server", "--save", "", "--appendonly", "no", "--maxmemory", "128mb",
+              "--maxmemory-policy", "allkeys-lru"]
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 5s
+
+volumes:
+  shorturl_data:
+    driver: local

--- a/static/style.css
+++ b/static/style.css
@@ -1,90 +1,555 @@
-/* ShortURL Service - minimal stylesheet */
-* {
+/* ============================================================
+   ShortURL Service - Enhanced Stylesheet
+   Responsive, modern design with card layout
+   ============================================================ */
+
+/* ── Reset & Base ────────────────────────────────────────── */
+*, *::before, *::after {
   box-sizing: border-box;
   margin: 0;
   padding: 0;
 }
 
+:root {
+  --primary:       #6366f1;
+  --primary-dark:  #4f46e5;
+  --primary-light: #e0e7ff;
+  --success:       #10b981;
+  --error:         #ef4444;
+  --error-bg:      #fef2f2;
+  --warning:       #f59e0b;
+
+  --bg:            #f0f2f5;
+  --card-bg:       #ffffff;
+  --border:        #e5e7eb;
+  --text-primary:  #1a1a2e;
+  --text-secondary:#6b7280;
+  --text-muted:    #9ca3af;
+
+  --radius-sm:     6px;
+  --radius-md:     12px;
+  --radius-lg:     16px;
+  --shadow-sm:     0 1px 3px rgba(0,0,0,.08);
+  --shadow-md:     0 4px 20px rgba(0,0,0,.08);
+  --shadow-lg:     0 8px 32px rgba(0,0,0,.12);
+  --transition:    0.2s ease;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
 body {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  background: #f0f2f5;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+               "Helvetica Neue", Arial, "PingFang SC", "Microsoft YaHei",
+               sans-serif;
+  background: var(--bg);
+  color: var(--text-primary);
+  min-height: 100vh;
+  line-height: 1.6;
+}
+
+/* ── App Layout ──────────────────────────────────────────── */
+.app-wrapper {
   display: flex;
-  align-items: center;
-  justify-content: center;
+  flex-direction: column;
   min-height: 100vh;
 }
 
-.container {
-  background: #fff;
-  border-radius: 12px;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
-  padding: 2.5rem 3rem;
-  max-width: 520px;
-  width: 100%;
-}
-
-h1 {
-  font-size: 1.8rem;
-  margin-bottom: 1.5rem;
-  color: #1a1a2e;
-}
-
-#shorten-form {
-  display: flex;
-  gap: 0.5rem;
-}
-
-input[type="url"] {
-  flex: 1;
-  padding: 0.6rem 0.9rem;
-  border: 1px solid #d1d5db;
-  border-radius: 6px;
-  font-size: 0.95rem;
-  outline: none;
-  transition: border-color 0.2s;
-}
-
-input[type="url"]:focus {
-  border-color: #6366f1;
-}
-
-button {
-  padding: 0.6rem 1.2rem;
-  background: #6366f1;
+/* ── Header ──────────────────────────────────────────────── */
+.site-header {
+  background: linear-gradient(135deg, var(--primary) 0%, var(--primary-dark) 100%);
   color: #fff;
-  border: none;
-  border-radius: 6px;
+  padding: 2rem 1.5rem 2.5rem;
+  text-align: center;
+}
+
+.header-inner {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.logo-icon {
+  font-size: 2rem;
+}
+
+.logo-text {
+  font-size: 1.8rem;
+  font-weight: 800;
+  letter-spacing: -0.5px;
+}
+
+.tagline {
   font-size: 0.95rem;
-  cursor: pointer;
-  transition: background 0.2s;
+  opacity: 0.85;
 }
 
-button:hover {
-  background: #4f46e5;
+/* ── Main Content ─────────────────────────────────────────── */
+.main-content {
+  flex: 1;
+  max-width: 720px;
+  width: 100%;
+  margin: -1.5rem auto 2rem;
+  padding: 0 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
 }
 
-#result {
-  margin-top: 1.2rem;
+/* ── Card ────────────────────────────────────────────────── */
+.card {
+  background: var(--card-bg);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+  padding: 1.75rem 2rem;
 }
 
-#result p {
-  color: #6b7280;
-  margin-bottom: 0.3rem;
-  font-size: 0.9rem;
+.card-title {
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 0.4rem;
 }
 
-#short-link {
-  color: #6366f1;
+.card-desc {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  margin-bottom: 1.25rem;
+}
+
+/* ── Form ────────────────────────────────────────────────── */
+.form-group {
+  margin-bottom: 1.1rem;
+}
+
+.form-label {
+  display: block;
+  font-size: 0.875rem;
   font-weight: 600;
+  color: var(--text-secondary);
+  margin-bottom: 0.4rem;
+}
+
+.form-input {
+  width: 100%;
+  padding: 0.65rem 0.9rem;
+  border: 1.5px solid var(--border);
+  border-radius: var(--radius-sm);
+  font-size: 0.95rem;
+  color: var(--text-primary);
+  background: #fff;
+  outline: none;
+  transition: border-color var(--transition), box-shadow var(--transition);
+}
+
+.form-input::placeholder {
+  color: var(--text-muted);
+}
+
+.form-input:focus {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
+}
+
+/* ── Expire Options ──────────────────────────────────────── */
+.expire-options {
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.expire-option input[type="radio"] {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.expire-btn {
+  display: inline-block;
+  padding: 0.4rem 1rem;
+  border: 1.5px solid var(--border);
+  border-radius: 20px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--transition);
+  user-select: none;
+}
+
+.expire-btn:hover {
+  border-color: var(--primary);
+  color: var(--primary);
+  background: var(--primary-light);
+}
+
+.expire-btn.active {
+  border-color: var(--primary);
+  color: var(--primary);
+  background: var(--primary-light);
+  font-weight: 600;
+}
+
+/* ── Buttons ─────────────────────────────────────────────── */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.65rem 1.4rem;
+  border: none;
+  border-radius: var(--radius-sm);
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition), transform var(--transition),
+              box-shadow var(--transition);
+  white-space: nowrap;
+}
+
+.btn:active {
+  transform: translateY(1px);
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.btn-primary {
+  width: 100%;
+  background: var(--primary);
+  color: #fff;
+  box-shadow: 0 2px 8px rgba(99,102,241,0.3);
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: var(--primary-dark);
+  box-shadow: 0 4px 12px rgba(99,102,241,0.4);
+}
+
+.btn-secondary {
+  background: var(--text-primary);
+  color: #fff;
+  flex-shrink: 0;
+}
+
+.btn-secondary:hover:not(:disabled) {
+  background: #2d2d4e;
+}
+
+.btn-copy {
+  padding: 0.45rem 0.9rem;
+  background: var(--primary-light);
+  color: var(--primary);
+  border-radius: var(--radius-sm);
+  font-size: 0.85rem;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.btn-copy:hover {
+  background: var(--primary);
+  color: #fff;
+}
+
+/* ── Alert ───────────────────────────────────────────────── */
+.alert {
+  margin-top: 1rem;
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-sm);
+  font-size: 0.875rem;
+}
+
+.alert-error {
+  background: var(--error-bg);
+  color: var(--error);
+  border: 1px solid #fecaca;
+}
+
+/* ── Result Section ──────────────────────────────────────── */
+.result-section {
+  margin-top: 1.5rem;
+  border-top: 1px solid var(--border);
+  padding-top: 1.5rem;
+}
+
+.result-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.result-icon {
+  font-size: 1.1rem;
+}
+
+.result-title {
+  font-weight: 700;
+  color: var(--success);
+}
+
+.result-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.result-url-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: var(--primary-light);
+  border-radius: var(--radius-sm);
+  padding: 0.75rem 1rem;
+  flex-wrap: wrap;
+}
+
+.short-url {
+  flex: 1;
+  color: var(--primary-dark);
+  font-weight: 700;
+  font-size: 1rem;
+  word-break: break-all;
+  text-decoration: none;
+  min-width: 0;
+}
+
+.short-url:hover {
+  text-decoration: underline;
+}
+
+/* ── Result Meta ─────────────────────────────────────────── */
+.result-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.meta-item {
+  font-size: 0.85rem;
+  display: flex;
+  gap: 0.4rem;
+  align-items: baseline;
+  flex-wrap: wrap;
+}
+
+.meta-label {
+  color: var(--text-secondary);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.meta-value {
+  color: var(--text-primary);
   word-break: break-all;
 }
 
-.error {
-  margin-top: 1rem;
-  color: #ef4444;
-  font-size: 0.9rem;
+.truncate {
+  max-width: 480px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: inline-block;
+  vertical-align: bottom;
 }
 
+/* ── QR Code ─────────────────────────────────────────────── */
+.qr-section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.6rem;
+  padding-top: 0.5rem;
+}
+
+.qr-label {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.qrcode-box {
+  border: 4px solid #fff;
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-sm);
+  background: #fff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 168px;
+  height: 168px;
+  overflow: hidden;
+}
+
+.qrcode-box canvas,
+.qrcode-box img {
+  display: block;
+}
+
+/* ── Stats Form Row ──────────────────────────────────────── */
+.stats-row {
+  display: flex;
+  gap: 0.6rem;
+  align-items: center;
+  margin-bottom: 0;
+}
+
+.stats-row .form-input {
+  flex: 1;
+  min-width: 0;
+}
+
+/* ── Stats Result ─────────────────────────────────────────── */
+.stats-result {
+  margin-top: 1.25rem;
+  border-top: 1px solid var(--border);
+  padding-top: 1.25rem;
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+  margin-bottom: 1.25rem;
+}
+
+.stat-card {
+  background: var(--bg);
+  border-radius: var(--radius-md);
+  padding: 1rem;
+  text-align: center;
+}
+
+.stat-value {
+  font-size: 1.75rem;
+  font-weight: 800;
+  color: var(--primary);
+  line-height: 1.2;
+}
+
+.stat-label {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  margin-top: 0.25rem;
+}
+
+.stats-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.detail-row {
+  display: flex;
+  gap: 0.75rem;
+  align-items: baseline;
+  font-size: 0.875rem;
+  flex-wrap: wrap;
+}
+
+.detail-label {
+  color: var(--text-secondary);
+  font-weight: 500;
+  white-space: nowrap;
+  flex-shrink: 0;
+  min-width: 72px;
+}
+
+.detail-value {
+  color: var(--text-primary);
+  word-break: break-all;
+}
+
+.link-overflow {
+  color: var(--primary);
+  text-decoration: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 460px;
+  display: inline-block;
+}
+
+.link-overflow:hover {
+  text-decoration: underline;
+}
+
+/* ── Footer ──────────────────────────────────────────────── */
+.site-footer {
+  text-align: center;
+  padding: 1.5rem 1rem;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+/* ── Utility ─────────────────────────────────────────────── */
 .hidden {
-  display: none;
+  display: none !important;
+}
+
+/* ── Responsive ──────────────────────────────────────────── */
+@media (max-width: 640px) {
+  .site-header {
+    padding: 1.5rem 1rem 2rem;
+  }
+
+  .logo-text {
+    font-size: 1.5rem;
+  }
+
+  .main-content {
+    margin-top: -1rem;
+    padding: 0 0.75rem;
+  }
+
+  .card {
+    padding: 1.25rem 1.25rem;
+  }
+
+  .result-url-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .stats-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .stats-row .btn-secondary {
+    width: 100%;
+  }
+
+  .stats-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .stat-value {
+    font-size: 1.4rem;
+  }
+
+  .truncate {
+    max-width: 200px;
+  }
+
+  .link-overflow {
+    max-width: 200px;
+  }
+}
+
+@media (max-width: 360px) {
+  .stats-grid {
+    grid-template-columns: 1fr;
+  }
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,370 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ShortURL Service - 短链接服务</title>
+  <link rel="stylesheet" href="/static/style.css" />
+  <!-- QRCode.js CDN -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"
+          integrity="sha512-CNgIRecGo7nphbeZ04Sc13ka07paqdeTu0WR1IM4kNcpmBAUSHSe2keGSWWRn8p/U+/8J15hCVTa5pf6ZJXFQ=="
+          crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+</head>
+<body>
+  <div class="app-wrapper">
+    <!-- Header -->
+    <header class="site-header">
+      <div class="header-inner">
+        <div class="logo">
+          <span class="logo-icon">🔗</span>
+          <span class="logo-text">ShortURL</span>
+        </div>
+        <p class="tagline">快速生成短链接，简洁高效</p>
+      </div>
+    </header>
+
+    <!-- Main Content -->
+    <main class="main-content">
+      <!-- Shorten Card -->
+      <section class="card" id="shorten-card">
+        <h2 class="card-title">生成短链接</h2>
+
+        <form id="shorten-form" novalidate>
+          <!-- URL Input -->
+          <div class="form-group">
+            <label class="form-label" for="url-input">长链接</label>
+            <input
+              type="url"
+              id="url-input"
+              class="form-input"
+              placeholder="https://example.com/your/very/long/url"
+              required
+              autocomplete="off"
+              spellcheck="false"
+            />
+          </div>
+
+          <!-- Expiry Selector -->
+          <div class="form-group">
+            <label class="form-label" for="expire-select">过期时间</label>
+            <div class="expire-options">
+              <label class="expire-option">
+                <input type="radio" name="expire_days" value="7" />
+                <span class="expire-btn">7天</span>
+              </label>
+              <label class="expire-option">
+                <input type="radio" name="expire_days" value="30" checked />
+                <span class="expire-btn active">30天</span>
+              </label>
+              <label class="expire-option">
+                <input type="radio" name="expire_days" value="90" />
+                <span class="expire-btn">90天</span>
+              </label>
+            </div>
+          </div>
+
+          <button type="submit" class="btn btn-primary" id="submit-btn">
+            <span class="btn-text">生成短链</span>
+            <span class="btn-loading hidden">处理中…</span>
+          </button>
+        </form>
+
+        <!-- Error Message -->
+        <div id="error-msg" class="alert alert-error hidden" role="alert"></div>
+
+        <!-- Result Section -->
+        <div id="result-section" class="result-section hidden">
+          <div class="result-header">
+            <span class="result-icon">✅</span>
+            <span class="result-title">短链接已生成</span>
+          </div>
+
+          <div class="result-body">
+            <!-- Short URL -->
+            <div class="result-url-row">
+              <a id="short-link" href="#" target="_blank" rel="noopener noreferrer" class="short-url"></a>
+              <button class="btn btn-copy" id="copy-btn" title="复制短链接">
+                <span>📋 复制</span>
+              </button>
+            </div>
+
+            <!-- Meta Info -->
+            <div class="result-meta">
+              <span class="meta-item">
+                <span class="meta-label">原始链接：</span>
+                <span id="original-url" class="meta-value truncate"></span>
+              </span>
+              <span class="meta-item">
+                <span class="meta-label">过期时间：</span>
+                <span id="expires-at" class="meta-value"></span>
+              </span>
+            </div>
+
+            <!-- QR Code -->
+            <div class="qr-section">
+              <p class="qr-label">扫码访问</p>
+              <div id="qrcode" class="qrcode-box"></div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Stats Card -->
+      <section class="card" id="stats-card">
+        <h2 class="card-title">查询统计</h2>
+        <p class="card-desc">输入短码查看访问统计</p>
+
+        <form id="stats-form" novalidate>
+          <div class="form-group stats-row">
+            <input
+              type="text"
+              id="stats-input"
+              class="form-input"
+              placeholder="输入短码，例如：aB3xY9"
+              maxlength="20"
+              autocomplete="off"
+              spellcheck="false"
+            />
+            <button type="submit" class="btn btn-secondary">查询</button>
+          </div>
+        </form>
+
+        <!-- Stats Error -->
+        <div id="stats-error" class="alert alert-error hidden" role="alert"></div>
+
+        <!-- Stats Result -->
+        <div id="stats-result" class="stats-result hidden">
+          <div class="stats-grid">
+            <div class="stat-card">
+              <div class="stat-value" id="stat-visits">—</div>
+              <div class="stat-label">总访问次数</div>
+            </div>
+            <div class="stat-card">
+              <div class="stat-value" id="stat-code">—</div>
+              <div class="stat-label">短码</div>
+            </div>
+          </div>
+          <div class="stats-detail">
+            <div class="detail-row">
+              <span class="detail-label">原始链接</span>
+              <a id="stat-original" href="#" target="_blank" rel="noopener noreferrer" class="detail-value link-overflow"></a>
+            </div>
+            <div class="detail-row">
+              <span class="detail-label">创建时间</span>
+              <span id="stat-created" class="detail-value"></span>
+            </div>
+            <div class="detail-row">
+              <span class="detail-label">过期时间</span>
+              <span id="stat-expires" class="detail-value"></span>
+            </div>
+            <div class="detail-row">
+              <span class="detail-label">最后访问</span>
+              <span id="stat-last-visit" class="detail-value"></span>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="site-footer">
+      <p>ShortURL Service &copy; 2025 &middot; Powered by FastAPI + Redis</p>
+    </footer>
+  </div>
+
+  <script>
+    // ─── Utilities ────────────────────────────────────────────────────────────
+
+    /**
+     * Format an ISO date string to locale-friendly display.
+     * @param {string} isoStr
+     * @returns {string}
+     */
+    function formatDate(isoStr) {
+      if (!isoStr) return '—';
+      try {
+        return new Date(isoStr).toLocaleString('zh-CN', {
+          year: 'numeric', month: '2-digit', day: '2-digit',
+          hour: '2-digit', minute: '2-digit',
+        });
+      } catch (e) {
+        return isoStr;
+      }
+    }
+
+    /**
+     * Show an alert element with the given message.
+     * @param {HTMLElement} el
+     * @param {string} msg
+     */
+    function showAlert(el, msg) {
+      el.textContent = msg;
+      el.classList.remove('hidden');
+    }
+
+    function hideAlert(el) {
+      el.classList.add('hidden');
+      el.textContent = '';
+    }
+
+    // ─── Expire Option Radio Styling ─────────────────────────────────────────
+    document.querySelectorAll('input[name="expire_days"]').forEach(radio => {
+      radio.addEventListener('change', () => {
+        document.querySelectorAll('.expire-btn').forEach(btn => btn.classList.remove('active'));
+        radio.nextElementSibling.classList.add('active');
+      });
+    });
+
+    // ─── QR Code Generator ───────────────────────────────────────────────────
+    let qrInstance = null;
+
+    /**
+     * Generate (or refresh) QR code for the given URL.
+     * @param {string} url
+     */
+    function generateQR(url) {
+      const container = document.getElementById('qrcode');
+      container.innerHTML = '';
+      qrInstance = new QRCode(container, {
+        text: url,
+        width: 160,
+        height: 160,
+        colorDark: '#1a1a2e',
+        colorLight: '#ffffff',
+        correctLevel: QRCode.CorrectLevel.M,
+      });
+    }
+
+    // ─── Copy Button ─────────────────────────────────────────────────────────
+    document.getElementById('copy-btn').addEventListener('click', async () => {
+      const link = document.getElementById('short-link').href;
+      try {
+        await navigator.clipboard.writeText(link);
+        const btn = document.getElementById('copy-btn');
+        btn.innerHTML = '<span>✅ 已复制</span>';
+        setTimeout(() => { btn.innerHTML = '<span>📋 复制</span>'; }, 2000);
+      } catch (e) {
+        // Fallback
+        const ta = document.createElement('textarea');
+        ta.value = link;
+        document.body.appendChild(ta);
+        ta.select();
+        document.execCommand('copy');
+        document.body.removeChild(ta);
+      }
+    });
+
+    // ─── Shorten Form ────────────────────────────────────────────────────────
+    document.getElementById('shorten-form').addEventListener('submit', async (e) => {
+      e.preventDefault();
+
+      const urlInput = document.getElementById('url-input');
+      const errorEl = document.getElementById('error-msg');
+      const resultSection = document.getElementById('result-section');
+      const submitBtn = document.getElementById('submit-btn');
+      const btnText = submitBtn.querySelector('.btn-text');
+      const btnLoading = submitBtn.querySelector('.btn-loading');
+
+      hideAlert(errorEl);
+      resultSection.classList.add('hidden');
+
+      // Get selected expire_days
+      const expireRadio = document.querySelector('input[name="expire_days"]:checked');
+      const expireDays = expireRadio ? parseInt(expireRadio.value, 10) : 30;
+
+      // Loading state
+      btnText.classList.add('hidden');
+      btnLoading.classList.remove('hidden');
+      submitBtn.disabled = true;
+
+      try {
+        const res = await fetch('/api/shorten', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ url: urlInput.value, expire_days: expireDays }),
+        });
+
+        const data = await res.json();
+
+        if (!res.ok) {
+          showAlert(errorEl, data.detail || '请求失败，请稍后重试。');
+          return;
+        }
+
+        // Populate result
+        const shortLinkEl = document.getElementById('short-link');
+        shortLinkEl.href = data.short_url;
+        shortLinkEl.textContent = data.short_url;
+
+        const originalEl = document.getElementById('original-url');
+        originalEl.textContent = data.original_url;
+        originalEl.title = data.original_url;
+
+        document.getElementById('expires-at').textContent = formatDate(data.expires_at);
+
+        resultSection.classList.remove('hidden');
+
+        // Generate QR code after element is visible
+        generateQR(data.short_url);
+
+        // Scroll result into view smoothly
+        resultSection.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+
+      } catch (err) {
+        showAlert(errorEl, '网络错误，请检查连接后重试。');
+      } finally {
+        btnText.classList.remove('hidden');
+        btnLoading.classList.add('hidden');
+        submitBtn.disabled = false;
+      }
+    });
+
+    // ─── Stats Form ──────────────────────────────────────────────────────────
+    document.getElementById('stats-form').addEventListener('submit', async (e) => {
+      e.preventDefault();
+
+      const input = document.getElementById('stats-input');
+      const errorEl = document.getElementById('stats-error');
+      const resultEl = document.getElementById('stats-result');
+
+      hideAlert(errorEl);
+      resultEl.classList.add('hidden');
+
+      const shortCode = input.value.trim();
+      if (!shortCode) {
+        showAlert(errorEl, '请输入短码。');
+        return;
+      }
+
+      try {
+        const res = await fetch(`/api/stats/${encodeURIComponent(shortCode)}`);
+        const data = await res.json();
+
+        if (!res.ok) {
+          showAlert(errorEl, data.detail || '未找到该短码。');
+          return;
+        }
+
+        document.getElementById('stat-visits').textContent = data.visit_count.toLocaleString();
+        document.getElementById('stat-code').textContent = data.short_code;
+
+        const origLink = document.getElementById('stat-original');
+        origLink.href = data.original_url;
+        origLink.textContent = data.original_url;
+        origLink.title = data.original_url;
+
+        document.getElementById('stat-created').textContent = formatDate(data.created_at);
+        document.getElementById('stat-expires').textContent = formatDate(data.expires_at);
+        document.getElementById('stat-last-visit').textContent =
+          data.last_visited_at ? formatDate(data.last_visited_at) : '尚未访问';
+
+        resultEl.classList.remove('hidden');
+        resultEl.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+
+      } catch (err) {
+        showAlert(errorEl, '网络错误，请检查连接后重试。');
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## 变更概览

完善了前端功能并添加了 Docker 部署支持。

Closes #3, Closes #4

---

## Task 3: 前端完善

- **Jinja2 模板**：将 `pages.py` 内联 HTML 迁移到 `templates/index.html`
- **过期时间选择**：7 / 30 / 90 天单选按钮，默认 30 天
- **二维码生成**：使用 QRCode.js CDN，生成短链后自动展示
- **统计查看**：输入短码即可查看访问次数、创建/过期/最后访问时间
- **响应式 UI**：卡片布局 + 渐变 Header，完整移动端适配
- **一键复制**：点击复制短链到剪贴板

## Task 4: Docker 部署

- **Dockerfile**：Python 3.11 slim 多阶段构建，非 root 运行，镜像体积更小
- **docker-compose.yml**：FastAPI + Redis 7，健康检查，SQLite 持久化卷
- **.dockerignore**：排除不必要文件减小构建上下文
- **README.md**：完整文档，包含 `docker-compose up` 快速开始、API 参考、环境变量说明

## 启动方式

```bash
git clone https://github.com/Richardpangster/shorturl-service.git
cd shorturl-service
docker-compose up -d
# 访问 http://localhost:8000
```

## 测试

所有 10 个现有测试全部通过，无警告。