### PR TITLE
feat: periodic background cleanup scheduler for expired URLs [#9]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,6 @@ SHORT_CODE_LENGTH=6
 
 # Short code collision protection: number of retries after the first attempt (0 = try once, no retries)
 SHORT_CODE_MAX_RETRIES=5
+
+# Periodic cleanup: interval in hours between expired URL cleanup runs (0 to disable)
+CLEANUP_INTERVAL_HOURS=1

--- a/app/config.py
+++ b/app/config.py
@@ -12,6 +12,7 @@ class Settings(BaseSettings):
     default_expire_days: int = 30
     short_code_length: int = 6
     short_code_max_retries: int = 5
+    cleanup_interval_hours: int = 1
 
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,6 @@
 """FastAPI application entry point for ShortURL Service."""
 
+import asyncio
 import logging
 from contextlib import asynccontextmanager
 from typing import AsyncIterator
@@ -8,11 +9,39 @@ from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 
 from app.cache import close_redis
+from app.config import settings
 from app.database import AsyncSessionLocal, init_db
 from app.routers import api, pages, redirect
-from app.services import cleanup_expired_urls
+from app.services import cleanup_expired_urls, cleanup_expired_urls_with_cache
 
 logger = logging.getLogger(__name__)
+
+
+async def _cleanup_loop() -> None:
+    """Background task that periodically cleans up expired URL records.
+
+    Runs every ``settings.cleanup_interval_hours`` hours.
+    If the interval is 0, the loop exits immediately (disabled).
+    """
+    interval_seconds = settings.cleanup_interval_hours * 3600
+    if interval_seconds <= 0:
+        logger.info("Periodic cleanup disabled (CLEANUP_INTERVAL_HOURS=0).")
+        return
+
+    logger.info(
+        "Periodic cleanup scheduler started (interval: %dh).",
+        settings.cleanup_interval_hours,
+    )
+    while True:
+        await asyncio.sleep(interval_seconds)
+        async with AsyncSessionLocal() as session:
+            try:
+                count = await cleanup_expired_urls_with_cache(session)
+                await session.commit()
+                logger.info("Periodic cleanup removed %d expired URL(s).", count)
+            except Exception as exc:  # pragma: no cover
+                logger.warning("Periodic cleanup failed: %s", exc)
+                await session.rollback()
 
 
 @asynccontextmanager
@@ -22,14 +51,15 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     On startup:
         - Initialises database tables.
         - Cleans up any expired short URL records.
+        - Starts background periodic cleanup task.
 
     On shutdown:
+        - Cancels the periodic cleanup task.
         - Closes Redis connection pool.
     """
-    # Startup
+    # Startup: init DB and run immediate cleanup
     await init_db()
 
-    # Clean up expired records on boot
     async with AsyncSessionLocal() as session:
         try:
             count = await cleanup_expired_urls(session)
@@ -40,9 +70,18 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             logger.warning("Startup cleanup failed: %s", exc)
             await session.rollback()
 
+    # Start background cleanup scheduler
+    cleanup_task = asyncio.create_task(_cleanup_loop())
+
     yield
 
-    # Shutdown
+    # Shutdown: cancel background task and close Redis
+    cleanup_task.cancel()
+    try:
+        await cleanup_task
+    except asyncio.CancelledError:
+        pass
+
     await close_redis()
 
 

--- a/app/services.py
+++ b/app/services.py
@@ -251,3 +251,42 @@ async def cleanup_expired_urls(db: AsyncSession) -> int:
     if deleted_count:
         logger.info("Cleaned up %d expired URL record(s).", deleted_count)
     return deleted_count
+
+
+async def cleanup_expired_urls_with_cache(db: AsyncSession) -> int:
+    """Delete all expired short URL records and evict their Redis cache entries.
+
+    Fetches the short codes of expired records first so they can be removed
+    from Redis, then bulk-deletes the rows from the database.
+
+    Args:
+        db: Async SQLAlchemy session.
+
+    Returns:
+        The number of records deleted.
+    """
+    now = _utcnow()
+
+    # Fetch short codes of expired records so we can evict them from Redis.
+    result = await db.execute(
+        select(URL.short_code).where(URL.expires_at < now)
+    )
+    expired_codes: list[str] = list(result.scalars().all())
+
+    if not expired_codes:
+        return 0
+
+    # Bulk delete expired rows.
+    del_result = await db.execute(
+        delete(URL).where(URL.short_code.in_(expired_codes))
+    )
+    deleted_count: int = del_result.rowcount  # type: ignore[assignment]
+
+    # Evict Redis cache entries for deleted codes.
+    for code in expired_codes:
+        await cache_delete(code)
+
+    if deleted_count:
+        logger.info("Cleaned up %d expired URL(s).", deleted_count)
+
+    return deleted_count

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1,0 +1,116 @@
+"""Tests for periodic cleanup scheduler (Issue #9)."""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.models import URL
+from app.services import cleanup_expired_urls_with_cache
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_cleanup_with_cache_deletes_expired(db_session):
+    """cleanup_expired_urls_with_cache removes expired records and returns count."""
+    now = _utcnow()
+
+    expired = URL(
+        short_code="EXPIR1",
+        original_url="https://expired.example.com/",
+        created_at=now - timedelta(days=2),
+        expires_at=now - timedelta(days=1),
+        visit_count=0,
+        last_visited_at=None,
+    )
+    active = URL(
+        short_code="ACTIV1",
+        original_url="https://active.example.com/",
+        created_at=now,
+        expires_at=now + timedelta(days=30),
+        visit_count=0,
+        last_visited_at=None,
+    )
+    db_session.add_all([expired, active])
+    await db_session.flush()
+
+    count = await cleanup_expired_urls_with_cache(db_session)
+    await db_session.commit()
+
+    assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_cleanup_with_cache_evicts_redis(db_session):
+    """cleanup_expired_urls_with_cache calls cache_delete for each expired code."""
+    now = _utcnow()
+
+    expired1 = URL(
+        short_code="DEL001",
+        original_url="https://del1.example.com/",
+        created_at=now - timedelta(days=2),
+        expires_at=now - timedelta(days=1),
+        visit_count=0,
+        last_visited_at=None,
+    )
+    expired2 = URL(
+        short_code="DEL002",
+        original_url="https://del2.example.com/",
+        created_at=now - timedelta(days=2),
+        expires_at=now - timedelta(days=1),
+        visit_count=0,
+        last_visited_at=None,
+    )
+    db_session.add_all([expired1, expired2])
+    await db_session.flush()
+
+    deleted_codes: list[str] = []
+
+    async def _mock_cache_delete(key: str) -> None:
+        deleted_codes.append(key)
+
+    with patch("app.services.cache_delete", side_effect=_mock_cache_delete):
+        count = await cleanup_expired_urls_with_cache(db_session)
+    await db_session.commit()
+
+    assert count == 2
+    assert set(deleted_codes) == {"DEL001", "DEL002"}
+
+
+@pytest.mark.asyncio
+async def test_cleanup_with_cache_no_expired(db_session):
+    """cleanup_expired_urls_with_cache returns 0 when nothing is expired."""
+    now = _utcnow()
+    active = URL(
+        short_code="NOEXP1",
+        original_url="https://noexp.example.com/",
+        created_at=now,
+        expires_at=now + timedelta(days=30),
+        visit_count=0,
+        last_visited_at=None,
+    )
+    db_session.add(active)
+    await db_session.flush()
+
+    count = await cleanup_expired_urls_with_cache(db_session)
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_cleanup_interval_disabled(client):
+    """When CLEANUP_INTERVAL_HOURS=0, _cleanup_loop exits immediately without sleeping."""
+    import asyncio
+
+    from app import config as cfg_module
+    from app.main import _cleanup_loop
+
+    original = cfg_module.settings.cleanup_interval_hours
+    cfg_module.settings.cleanup_interval_hours = 0
+    try:
+        # Should return quickly (no sleep)
+        await asyncio.wait_for(_cleanup_loop(), timeout=2.0)
+    finally:
+        cfg_module.settings.cleanup_interval_hours = original


### PR DESCRIPTION
## 关联 Issue
Closes #9

## 变更内容

### `app/config.py`
- 新增 `cleanup_interval_hours: int = 1` 配置项（环境变量 `CLEANUP_INTERVAL_HOURS`）

### `app/services.py`
- 新增 `cleanup_expired_urls_with_cache(db)`：查出过期 short_code → 批量删 DB → 逐一 evict Redis，返回删除数量

### `app/main.py`
- 新增 `_cleanup_loop()` 协程：每 `CLEANUP_INTERVAL_HOURS` 小时执行一次 `cleanup_expired_urls_with_cache`；`interval=0` 直接退出（禁用）
- `lifespan` 中用 `asyncio.create_task` 启动后台任务，shutdown 时 `cancel()` 干净退出
- 保留原有启动时单次清理逻辑（向后兼容）

### `.env.example`
- 补充 `CLEANUP_INTERVAL_HOURS=1` 说明

### `tests/test_cleanup.py`（新文件）
- `test_cleanup_with_cache_deletes_expired`：验证过期记录被删除
- `test_cleanup_with_cache_evicts_redis`：验证 cache_delete 被调用
- `test_cleanup_with_cache_no_expired`：无过期记录时返回 0
- `test_cleanup_interval_disabled`：interval=0 时 loop 立即退出

## 测试结果
```
16 passed in 0.19s
```

## 验收对照
- [x] 使用 asyncio.Task 在 lifespan 中实现后台定时清理（零外部依赖）
- [x] 默认 1 小时，可通过 CLEANUP_INTERVAL_HOURS 配置
- [x] 清理时同步删除 Redis 对应缓存键
- [x] logger 打印删除条数
- [x] 保留启动时清理兼容
- [x] config.py 新增配置项
- [x] .env.example 补充说明
- [x] 新增测试覆盖